### PR TITLE
moved tlscheck into model/auth

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -54,13 +54,15 @@ tasks:
       - mkdir -p {{.devdir}}/certs
       - mkdir -p _registry
 
-      # create stuff for local registry
-      - echo "Generate htpasswd for registry .."
+      # create registry htpasswd
+      - echo "Generate registry htpasswd registry .."
       - '{{.PODEXE}} run --rm --entrypoint htpasswd httpd:2 -Bbn {{.REGISTRY_USER}} {{.REGISTRY_PASSWORD}} > {{.devdir}}/htpasswd'
-      - echo "Generate certificats for registry .."
+      
+      # create registry certificates
+      - echo "Generate registry certificats .."
       - openssl req -newkey rsa:4096 -nodes -sha256 -addext "subjectAltName=DNS:localhost" -keyout {{.devdir}}/certs/domain.key -x509 -days 365 -out {{.devdir}}/certs/domain.crt -subj "/CN=localhost" 2>/dev/null
 
-      # trust certificate for docker/podman client
+      # create registry certificates
       - echo "**** copy domain.crt to {{.PODEXE}} certificate to the client trust it ****"
       - echo "podman             cp {{.devdir}}/certs/domain.crt /etc/containers/certs.d/localhost:5000/ca.crt"
       - echo "podman (rootless)  cp {{.devdir}}/certs/domain.crt ~/.config/containers/certs.d/localhost:5000/ca.crt"

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -14,11 +14,29 @@ func TestDSN(t *testing.T) {
 	// user+pwd
 	err = auth.FromDsn("registry://user:pwd@docker.io:123")
 	assert.NoError(t, err)
-
-	assert.Equal(t, "registry://user:***@docker.io:123", auth.ToMaskedDsn("***"))
+	assert.Equal(t, "registry://user:***@docker.io:123/?tlscheck=true", auth.ToMaskedDsn("***"))
 	assert.Equal(t, "docker.io:123", auth.Authority)
 	assert.Equal(t, "user", auth.Username)
 	assert.Equal(t, "pwd", auth.Password)
 	assert.Equal(t, "", auth.Token)
+	assert.Equal(t, true, auth.TlsCheck)
 
+	// user+pwd
+	err = auth.FromDsn("registry://user:pwd@docker.io/?tlscheck=off")
+	assert.NoError(t, err)
+	assert.Equal(t, "registry://user:***@docker.io/?tlscheck=false", auth.ToMaskedDsn("***"))
+	assert.Equal(t, "docker.io", auth.Authority)
+	assert.Equal(t, "user", auth.Username)
+	assert.Equal(t, "pwd", auth.Password)
+	assert.Equal(t, "", auth.Token)
+	assert.Equal(t, false, auth.TlsCheck)
+
+	err = auth.FromDsn("registry://docker.io/?tlscheck=off")
+	assert.NoError(t, err)
+	assert.Equal(t, "docker.io", auth.Authority)
+	assert.Equal(t, "", auth.Username)
+	assert.Equal(t, "", auth.Password)
+	assert.Equal(t, "", auth.Token)
+	assert.Equal(t, false, auth.TlsCheck)
+	assert.Equal(t, "registry://docker.io/?tlscheck=false", auth.ToMaskedDsn("***"))
 }


### PR DESCRIPTION
- removed tlscheck command line argument
- tlscheck is now give per repo in repo_auth as registry://docker.io/?tlscheck=off